### PR TITLE
rpm: remove old trailing directory during upgrade

### DIFF
--- a/api/loudml-api.spec
+++ b/api/loudml-api.spec
@@ -27,6 +27,11 @@ make clean
 
 %pre
 
+# Remove old trailing files. Required for users who have installed <1.3.3
+find %{python3_sitelib} \
+  -name '*loudml_api-1.3.0.*.egg-info' \
+  | xargs rm -rf
+
 %install
 cd api
 make install DESTDIR=%{buildroot}
@@ -34,7 +39,7 @@ make install DESTDIR=%{buildroot}
 %files
 %defattr(-,root,root,-)
 %{python3_sitelib}/loudml/*
-%{python3_sitelib}/loudml_api-*.egg-info/*
+%dir %{python3_sitelib}/loudml_api-*.egg-info
 %{python3_sitelib}/loudml_api-*.pth
 
 %doc


### PR DESCRIPTION
Warnings are shown, but we cannot get rid of them.

Signed-off-by: Vianney Bajart <vianney@redmintnetwork.fr>