### PR TITLE
API: Deb package version

### DIFF
--- a/api/debian/changelog.in
+++ b/api/debian/changelog.in
@@ -1,4 +1,4 @@
-loudml-api (1.4.2) unstable; urgency=low
+loudml-api (@VERSION@) unstable; urgency=low
 
   * Initial release
 


### PR DESCRIPTION
## Changes

- use existing scripts to compute version number from tags in the Git
  repository

## Tests

Set a local tag `v1.5.0.rc1` and build package with `make deb`. The package that has been generated includes the correct version number: `loudml-api_1.5.0.rc1_all.deb` (test OK)