### PR TITLE
Telemetry: collect statistics from Docker Hub

### DIFF
--- a/telemetry/Gopkg.lock
+++ b/telemetry/Gopkg.lock
@@ -14,6 +14,12 @@
 
 [[projects]]
   branch = "master"
+  name = "github.com/jasonlvhit/gocron"
+  packages = ["."]
+  revision = "6771d4b492ba2d5f57919c04b4cddb3735365120"
+
+[[projects]]
+  branch = "master"
   name = "github.com/osunac/go-httplogger"
   packages = ["."]
   revision = "c938b2e071fb6deaaa98bba52daa3fcf195474e0"
@@ -21,6 +27,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "24becc08cf93b14ceeea137aa4655605201258e30b514df0f45dc36338c5526f"
+  inputs-digest = "af1664c0a2b6abb710d26425847f06acf3b744a5f8e5de62d6b9e972316fa12d"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/telemetry/Gopkg.toml
+++ b/telemetry/Gopkg.toml
@@ -28,3 +28,7 @@
 [[constraint]]
   branch = "master"
   name = "github.com/osunac/go-httplogger"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/jasonlvhit/gocron"

--- a/telemetry/README.md
+++ b/telemetry/README.md
@@ -1,6 +1,11 @@
 # Telemetry
 
-This package collects information about a running instance of Loud ML.
+This program collects information about how Loud ML is used and saves it into
+a database.
+
+More into details, it collects:
+- count of `docker pull` images from Docker Hub;
+- user environment of running instances of Loud ML deamon.
 
 Because of regulation, personnal information cannot be stored in a database.
 This applies to e-mail for instance.

--- a/telemetry/dockerhub.go
+++ b/telemetry/dockerhub.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+type ImageInfo struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+	PullCount int    `json:"pull_count"`
+	StarCount int    `json:"star_count"`
+	// other fields ignored
+}
+
+func imageInfoFromJSON(jsonBlob []byte) (ImageInfo, error) {
+	i := ImageInfo{StarCount: -1, PullCount: -1}
+
+	if !json.Valid(jsonBlob) {
+		return i, errors.New("invalid JSON")
+	}
+
+	err := json.Unmarshal(jsonBlob, &i)
+	if err != nil {
+		return i, err
+	}
+
+	if i.Name == "" {
+		return i, errors.New("missing field name")
+	}
+
+	if i.Namespace == "" {
+		return i, errors.New("missing field namespace")
+	}
+
+	if i.PullCount == -1 {
+		return i, errors.New("missing field pull_count")
+	}
+
+	if i.StarCount == -1 {
+		return i, errors.New("missing field start_count")
+	}
+
+	return i, nil
+}
+
+func (i ImageInfo) fields() map[string]interface{} {
+	res := map[string]interface{}{
+		"pull_count": i.PullCount,
+		"star_count": i.StarCount,
+	}
+
+	return res
+}
+
+func (i ImageInfo) tags() map[string]string {
+	res := map[string]string{
+		"user-agent": "docker",
+		"image":      i.Namespace + "/" + i.Name,
+	}
+
+	return res
+}

--- a/telemetry/dockerhub_test.go
+++ b/telemetry/dockerhub_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestDockerHubParse(t *testing.T) {
+	var i ImageInfo
+	json1 := []byte(`
+{"user": "loudml", "name": "community", "namespace": "loudml", "repository_type": "image", "status": 1, "description": "Loud ML is the first open-source AI solution for ICT and IoT automation.", "is_private": false, "is_automated": false, "can_edit": false, "star_count": 3, "pull_count": 28844, "last_updated": "2019-02-16T06:44:05.637411Z", "is_migrated": false, "has_starred": false, "full_description": "...", "affiliation": null, "permissions": {"read": true, "write": false, "admin": false}}
+`)
+
+	i, _ = imageInfoFromJSON(json1)
+	if i.StarCount != 3 {
+		t.Errorf("error: expected %d, got %d", 3, i.StarCount)
+	}
+	if i.PullCount != 28844 {
+		t.Errorf("error: expected %d, got %d", 28844, i.PullCount)
+	}
+	if i.Name != "community" {
+		t.Errorf("error: expected '%s', got '%s'", "community", i.Name)
+	}
+	if i.Namespace != "loudml" {
+		t.Errorf("error: expected '%s', got '%s'", "loudml", i.Name)
+	}
+}
+
+func NewImageInfo() ImageInfo {
+	i := ImageInfo{
+		Name:      "community",
+		Namespace: "loudml",
+		PullCount: 10000,
+		StarCount: 3,
+	}
+
+	return i
+}
+
+func TestImageInfoTags(t *testing.T) {
+	i := NewImageInfo()
+	expect := map[string]string{
+		"user-agent": "docker",
+		"image":      "loudml/community",
+	}
+	res := i.tags()
+	if !reflect.DeepEqual(res, expect) {
+		t.Errorf("error: expected '%s', got '%s'", expect, res)
+	}
+}
+
+func TestImageInfoFields(t *testing.T) {
+	i := NewImageInfo()
+	expect := map[string]interface{}{
+		"pull_count": i.PullCount,
+		"star_count": i.StarCount,
+	}
+	res := i.fields()
+	if !reflect.DeepEqual(res, expect) {
+		t.Errorf("error: expected '%s', got '%s'", expect, res)
+	}
+}

--- a/telemetry/main.go
+++ b/telemetry/main.go
@@ -3,22 +3,26 @@ package main
 import (
 	"fmt"
 	"github.com/influxdata/influxdb/client/v2"
+	"github.com/jasonlvhit/gocron"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"strconv"
+	"sync"
 	"time"
 
 	httplogger "github.com/osunac/go-httplogger"
 )
 
 const (
-	database     = "telemetry"
-	influxdb_url = "http://localhost:8086"
-	measurement  = "telemetry"
+	database      = "telemetry"
+	dockerhub_url = "https://hub.docker.com/v2/repositories/loudml/community/"
+	influxdb_url  = "http://localhost:8086"
+	measurement   = "telemetry"
 )
 
 var db client.Client
+var db_lock = &sync.Mutex{}
 
 func influxDBClient() client.Client {
 	c, err := client.NewHTTPClient(client.HTTPConfig{
@@ -71,7 +75,9 @@ func route_api(w http.ResponseWriter, r *http.Request) {
 		}
 		bp.AddPoint(pt)
 
+		db_lock.Lock()
 		err = db.Write(bp)
+		db_lock.Unlock()
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -81,9 +87,58 @@ func route_api(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+func collectDockerHubStats() {
+	c := http.Client{}
+
+	req, err := http.NewRequest("GET", dockerhub_url, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	resp, err := c.Do(req)
+	if err != nil {
+		log.Printf("%s", err)
+		return
+	}
+
+	jsonBlob, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	i, err := imageInfoFromJSON(jsonBlob)
+	if err != nil {
+		log.Printf("error while parsing DockerHub JSON: %s", err)
+		return
+	}
+
+	bp, _ := client.NewBatchPoints(client.BatchPointsConfig{
+		Database:  database,
+		Precision: "s",
+	})
+
+	pt, err := client.NewPoint(measurement, i.tags(), i.fields(), time.Now())
+	if err != nil {
+		log.Fatal(err)
+	}
+	bp.AddPoint(pt)
+
+	db_lock.Lock()
+	err = db.Write(bp)
+	db_lock.Unlock()
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
 func main() {
 	db = influxDBClient()
 	defer db.Close()
+
+	collectDockerHubStats()
+	gocron.Every(1).Hour().Do(collectDockerHubStats)
+	<-gocron.Start()
 
 	serveMux := http.NewServeMux()
 


### PR DESCRIPTION
Every hour, fetch statistics from DockerHub and store the information into the metrics Influxdb database.

Tags:
- `user-agent`: `docker`
- `image`: `loudml/community`

Fields:
- `pull_count`: actual value
- `star_count`: actual value

## Tests

Unit tests: OK

Integration test:
- tags and fields described above are correctly inserted into the database
- by replacing the "every hour" in the code by "every 10 seconds", the database is updated with the expected frequency
