### PR TITLE
Update ubuntu.asciidoc

### DIFF
--- a/docs/reference/setup/install/ubuntu.asciidoc
+++ b/docs/reference/setup/install/ubuntu.asciidoc
@@ -23,7 +23,7 @@ Ubuntu 18.04 ships with Python 3.6. You will need to install the following depen
 
 [source,sh]
 --------------------------------------------------
-apt-get install python3-lib2to3
+apt-get install python3
 --------------------------------------------------
 
 [[ubuntu-repo]]


### PR DESCRIPTION
In the installation of dependency step of python3, it is giving below error :
"Package python3-lib2to3 is not available but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or is only available from another source"
So because Package python3-lib2to3 is not available I have changed that with the only python3.