### PR TITLE
check create_database config option prior to force create annotation database

### DIFF
--- a/loudml/influx.py
+++ b/loudml/influx.py
@@ -414,7 +414,8 @@ class InfluxBucket(Bucket):
                 ssl=self.use_ssl,
                 verify_ssl=self.verify_ssl,
             )
-            self._annotationdb.create_database(db)
+            if self.cfg.get('create_database'):
+                self._annotationdb.create_database(db)
 
         return self._annotationdb
 


### PR DESCRIPTION
this commit fix #122, and enables non admin READ/WRITE users access to the database.