### PR TITLE
Enable influxdb basic Auth settings

### DIFF
--- a/docker/compose/docker-compose.yml
+++ b/docker/compose/docker-compose.yml
@@ -4,7 +4,7 @@ version: "3.6"
 
 services:
   loudml:
-    image: loudml/loudml:1.6.0
+    image: loudml/loudml
     volumes:
       - ./etc/loudml.yml:/etc/loudml/config.yml:ro
       - var_loudml
@@ -14,11 +14,16 @@ services:
       - influxdb
 
   influxdb:
-    image: influxdb
+    image: influxdb:alpine
     ports:
       - "8086:8086"
     volumes:
       - var_influxdb
+      - ./etc/influx_init.iql:/docker-entrypoint-initdb.d/influx_init.iql
+    environment:
+      INFLUXDB_HTTP_AUTH_ENABLED: "true"
+      INFLUXDB_ADMIN_USER: "admin"
+      INFLUXDB_ADMIN_PASSWORD: "passw0rd"
 
   chronograf:
     image: loudml/chronograf
@@ -31,21 +36,25 @@ services:
     volumes:
       - var_chronograf
     environment:
+      INFLUXDB_USERNAME: "admin"
+      INFLUXDB_PASSWORD: "passw0rd"
       INFLUXDB_URL: http://influxdb:8086
       LOUDML_URL: http://loudml:8077
       KAPACITOR_URL: http://kapacitor:9092
 
   kapacitor:
-    image: kapacitor
+    image: kapacitor:alpine
     depends_on:
       - influxdb
     volumes:
       - var_kapacitor
     environment:
       KAPACITOR_INFLUXDB_0_URLS_0: http://influxdb:8086
+      KAPACITOR_INFLUXDB_0_USERNAME: "admin"
+      KAPACITOR_INFLUXDB_0_PASSWORD: "passw0rd"
 
   telegraf:
-    image: telegraf
+    image: telegraf:alpine
     volumes:
       - ./etc/telegraf.conf:/etc/telegraf/telegraf.conf:ro
     depends_on:

--- a/docker/compose/etc/influx_init.iql
+++ b/docker/compose/etc/influx_init.iql
@@ -1,0 +1,14 @@
+CREATE DATABASE "telegraf"
+CREATE DATABASE "loudml"
+CREATE DATABASE "chronograf"
+CREATE USER telegraf WITH PASSWORD 'metricsmetricsmetricsmetrics'
+REVOKE ALL PRIVILEGES FROM telegraf
+GRANT WRITE ON telegraf TO telegraf
+CREATE USER reader WITH PASSWORD 'metricsmetricsmetricsmetrics'
+REVOKE ALL PRIVILEGES FROM reader
+GRANT READ ON telegraf TO reader
+GRANT READ ON chronograf TO reader
+CREATE USER loudml WITH PASSWORD 'metricsmetricsmetricsmetrics'
+REVOKE ALL PRIVILEGES FROM loudml
+GRANT WRITE ON loudml TO loudml
+GRANT ALL ON chronograf TO loudml

--- a/docker/compose/etc/loudml.yml
+++ b/docker/compose/etc/loudml.yml
@@ -4,14 +4,19 @@ buckets:
     type: influxdb
     addr: influxdb:8086
     database: loudml
+    dbuser: loudml
+    dbuser_password: "metricsmetricsmetricsmetrics"
     retention_policy: autogen
     measurement: loudml
+    create_database: false
   - name: data
     type: influxdb
     addr: influxdb:8086
-    database: data
+    database: telegraf
+    dbuser: reader
+    dbuser_password: "metricsmetricsmetricsmetrics"
     retention_policy: autogen
-    measurement: sinus
+    create_database: false
 
 storage:
   path: /var/lib/loudml

--- a/docker/compose/etc/telegraf.conf
+++ b/docker/compose/etc/telegraf.conf
@@ -113,8 +113,8 @@
   # timeout = "5s"
 
   ## HTTP Basic Auth
-  # username = "telegraf"
-  # password = "metricsmetricsmetricsmetrics"
+  username = "telegraf"
+  password = "metricsmetricsmetricsmetrics"
 
   ## HTTP User-Agent
   # user_agent = "telegraf"

--- a/loudml/influx.py
+++ b/loudml/influx.py
@@ -414,7 +414,6 @@ class InfluxBucket(Bucket):
                 ssl=self.use_ssl,
                 verify_ssl=self.verify_ssl,
             )
-            self._annotationdb.create_database(db)
 
         return self._annotationdb
 

--- a/loudml/influx.py
+++ b/loudml/influx.py
@@ -678,7 +678,16 @@ class InfluxBucket(Bucket):
         )
 
         query = ''.join(query)
-        result = self.annotationdb.query(query)
+        try:
+            result = self.annotationdb.query(query)
+        except influxdb.exceptions.InfluxDBClientError as exn:
+            logging.warning(
+                "could not load annotations, got error '%d'",
+                exn.code,
+            )
+            if exn.code == 401:
+                return []
+            raise exn
 
         windows = []
         for j, point in enumerate(result.get_points()):

--- a/loudml/worker.py
+++ b/loudml/worker.py
@@ -255,7 +255,7 @@ class Worker:
             if detect_anomalies:
                 hooks = self.storage.load_model_hooks(
                     model.settings,
-                    bucket,
+                    output_bucket or bucket,
                 )
                 model.detect_anomalies(prediction, hooks)
             if save_run_state:


### PR DESCRIPTION
WIP

Outstanding issues:

- [ ] Chronograf adds new buckets behind the scenes as the user navigates in the data explorer. These new buckets are missing authentication parameters, causing training to fail in `list_anomalies()` with error `401: authorization failed`
- [ ] Chronograf `measurement` and `field` drop-down lists are empty if authentication is enabled

<img width="1226" alt="Screen Shot 2020-08-04 at 20 20 19" src="https://user-images.githubusercontent.com/355557/89330625-d8d9ab80-d690-11ea-9c31-9a41d4bc6669.png">
