### PR TITLE
extend character validations for model,fields,tags  and measurement names , fix #392

### DIFF
--- a/loudml/model.py
+++ b/loudml/model.py
@@ -77,9 +77,9 @@ class Feature:
     SCHEMA = Schema({
         Required('name'): All(schemas.key, Length(max=256)),
         Required('metric'): All(schemas.key, Length(max=256)),
-        Required('field'): All(schemas.dotted_key, Length(max=256)),
+        Required('field'): All(schemas.key, Length(max=256)),
         'bucket': Any(None, schemas.key),
-        'measurement': Any(None, schemas.dotted_key),
+        'measurement': Any(None, schemas.key),
         'match_all': Any(None, Schema([
             {Required(schemas.key): Any(
                 int,
@@ -157,13 +157,13 @@ class FeatureTemplate(Feature):
             All(schemas.bracket_key, Length(max=256)),
         ),
         Required('field'): Any(
-            All(schemas.dotted_key, Length(max=256)),
+            All(schemas.key, Length(max=256)),
             All(schemas.bracket_key, Length(max=256)),
         ),
         'bucket': Any(
             None, schemas.key, schemas.bracket_key),
         'measurement': Any(
-            None, schemas.dotted_key, schemas.bracket_key),
+            None, schemas.key, schemas.bracket_key),
         'match_all': Any(
             None,
             Schema([

--- a/loudml/schemas.py
+++ b/loudml/schemas.py
@@ -28,19 +28,13 @@ from .misc import (
 key = All(
     str,
     Length(min=1),
-    Match("^[a-zA-Z0-9-_@]+$"),
+    Match("^[a-zA-Z0-9-_@\/\[\]{}:;,.|=%\"\$]+$"),
 )
 
 time_str_key = All(
     str,
     Length(min=1),
     Match("^[:0-9]+$"),
-)
-
-dotted_key = All(
-    str,
-    Length(min=1),
-    Match("^[a-zA-Z0-9-_@.]+$"),
 )
 
 bracket_key = All(

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -38,11 +38,6 @@ class TestModel(unittest.TestCase):
 
         # Invalid
         self.invalid_feature(
-            name="foo/invalid",
-            field="bar",
-            metric="avg",
-        )
-        self.invalid_feature(
             metric="avg",
             field="bar",
         )
@@ -160,19 +155,6 @@ class TestModel(unittest.TestCase):
                         'metric': 'count',
                         'io': 'o',
                     }
-                ],
-            }
-        )
-        self.invalid_model(
-            settings={
-                'name': 'foo/invalid',
-                'type': 'generic',
-                'features': [
-                    {
-                        'name': 'bar',
-                        'field': 'baz',
-                        'metric': 'avg',
-                    },
                 ],
             }
         )

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -22,10 +22,15 @@ class TestSchemas(unittest.TestCase):
         self.valid("Foo-Bar")
         self.valid("00_foo_00_bar_001")
         self.valid("_foo")
+        self.valid("traffic.rxt_et-1/0/0")
+        self.valid("traffic.rxt_et-[1/0/0]")
+        self.valid("traffic.rxt_et-{1/0/0}")
+        self.valid("traffic.rxt_et-00:11:11")
+        self.valid("traffic.rxt_et=adfa")
+        self.valid("traffic.rxt_et=\"foo\"")
+        self.valid("traffic.rxt_et=${value}")
 
         self.invalid("")
-        self.invalid("foo/bar")
-        self.invalid(".foo")
 
     def test_timestamp(self):
         self.schema = schemas.Timestamp()


### PR DESCRIPTION
Hi @regel here the PR , I've removed dotted_key as in standar key the dot is included. Aso added test key as suggested last week.
Currently tested and working  with this image `tonimoreno/loudml:1.6.2`

as you can see here.

```
> show-model MY_MODEL
- settings:
    bucket_interval: 10m
    default_bucket: XXXXXXX
    features:
    - anomaly_type: low_high
      field: value
      io: io
      match_all:
      - tag: metric_id
        value: '2123123'
      measurement: traffic.rxt_et-1/0/0 <---------------------------HERE OK!
      metric: mean
      name: mean_value
    grace_period: 0
    interval: 60s
    max_evals: 20
    max_threshold: 70
    min_threshold: 50
    name: MY_MODEL
    offset: 1h
    run:
      flag_abnormal_data: true
      output_bucket: XXXXXXXXXXXXXXXXXX
      save_output_data: true
    seasonality:
      daytime: true
      weekday: true
    span: 256
    type: donut
```